### PR TITLE
Ticket1692 temperature setpoint

### DIFF
--- a/lakeshore336/lakeshore336App/Db/lakeshore336.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336.template
@@ -21,7 +21,7 @@ record(bo, "$(P):SIM") {
 record(bo, "$(P):DISABLE") {
   field(DESC, "Disable comms")
   field(PINI, "YES")
-  field(VAL, "0")
+  field(VAL, "$(DISABLE=0)")
   field(OMSL, "supervisory")
   field(ZNAM, "COMMS ENABLED")
   field(ONAM, "COMMS DISABLED")

--- a/lakeshore336/lakeshore336App/Db/lakeshore336loop.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336loop.template
@@ -32,6 +32,8 @@ record(ai, "$(P):HEATER$(OUT):OUTPUT") {
 
 ## 
 ## Define the strings and values for this record.
+## IMPORTANT: the rest of the record is defined in the output file, which
+## contains records common to all output types
 ##
 record(mbbi, "$(P):HEATER$(OUT):RANGE") {
   field(ZRST, "Off")
@@ -42,6 +44,8 @@ record(mbbi, "$(P):HEATER$(OUT):RANGE") {
 
 ##
 ## Define the strings and values for this record.
+## IMPORTANT: the rest of the record is defined in the output file, which
+## contains records common to all output types
 ##
 record(mbbi, "$(P):OUT_MODE$(OUT)") {
   field(ZRST, "Off")
@@ -52,7 +56,9 @@ record(mbbi, "$(P):OUT_MODE$(OUT)") {
 
 ## 
 ## Define the strings and values for this record.
-## 
+## IMPORTANT: the rest of the record is defined in the output file, which
+## contains records common to all output types
+##
 record(mbbo, "$(P):HEATER$(OUT):RANGE:SP") {
   field(ZRST, "Off")
   field(ONST, "Low")
@@ -62,6 +68,8 @@ record(mbbo, "$(P):HEATER$(OUT):RANGE:SP") {
 
 ##
 ## Define the strings and values for this record.
+## IMPORTANT: the rest of the record is defined in the output file, which
+## contains records common to all output types
 ##
 record(mbbo, "$(P):OUT_MODE$(OUT):SP") {
   field(ZRST, "Off")

--- a/lakeshore336/lakeshore336App/Db/lakeshore336output.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336output.template
@@ -49,6 +49,46 @@ record(ai, "$(P):TEMP$(OUT):SP:RBV") {
   info(archive, "VAL")
 }
 
+##
+## A few records to fetch the temperature read on the corresponding input channel
+## This is so users can define a block as TEMP_1
+record(calcout, "$(P):SELECT_WHICH_TEMP$(OUT)") {
+  field(INPA, "$(P):CTRL_IN$(OUT).VAL CP")
+  field(CALC, "A<=4 ? A : 0")
+  field(OUT, "$(P):FETCH_TEMP$(OUT).SELN PP")
+}
+
+record(ai, "$(P):DUMMY_TEMP$(OUT)") {
+  field(DESC, "Dummy to use when CtrlInput is None")
+}
+
+record(sel, "$(P):FETCH_TEMP$(OUT)") {
+  field(INPA, "$(P):DUMMY_TEMP$(OUT)")
+  field(INPB, "$(P):TEMP_A CP")
+  field(INPC, "$(P):TEMP_B CP")
+  field(INPD, "$(P):TEMP_C CP")
+  field(INPE, "$(P):TEMP_D CP")
+  field(SELM, "Specified")
+  field(FLNK, "$(P):TEMP$(OUT)")
+}
+
+record(ai, "$(P):TEMP$(OUT)") {
+  field(DESC, "Temp read on input channel for output $(OUT)")
+  field(INP, "$(P):FETCH_TEMP$(OUT)")
+  field(PREC, "3")
+  field(EGU, "K")
+  field(HHSV,"MAJOR")
+  field(HSV, "MINOR")
+  field(LSV, "MINOR")
+  field(LLSV,"MAJOR")
+  field(HIHI,"1000")
+  field(HIGH,"1000")
+  field(LOW,"-1")
+  field(LOLO,"-1")
+  info(INTEREST, "HIGH")
+  info(archive, "VAL")
+}
+
 ## 
 ## Read the ramp rate parameter. This also populates the ramp status $(P):RAMP_ON$(OUT),
 ##

--- a/lakeshore336/lakeshore336App/Db/lakeshore336output.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336output.template
@@ -45,13 +45,42 @@ record(ai, "$(P):TEMP$(OUT):SP:RBV") {
   field(EGU, "K")
   field(SIML, "$(P):SIM")
   field(SIOL, "$(P):SIM:TEMP$(OUT):SP:RBV")
+  field(FLNK, "$(P):PUSH_TEMP$(OUT):SP:RBV")
   info(INTEREST, "HIGH")
   info(archive, "VAL")
 }
 
 ##
+## A few records to push the setpoint RBV to the corresponding PV in the input
+##
+record(calcout, "$(P):SELECT_WHICH_TEMP$(OUT):SP:RBV") {
+  field(INPA, "$(P):CTRL_IN$(OUT).VAL CP")
+  field(CALC, "A<=4 ? A+1 : 1")
+  field(OUT, "$(P):PUSH_TEMP$(OUT):SP:RBV.SELN PP")
+}
+
+record(ai, "$(P):DUMMY_TEMP$(OUT):SP:RBV") {
+  field(DESC, "Dummy to use when CtrlInput is None")
+}
+
+record(seq, "$(P):PUSH_TEMP$(OUT):SP:RBV") {
+  field(DOL1, "$(P):TEMP$(OUT):SP:RBV CP")
+  field(LNK1, "$(P):DUMMY_TEMP$(OUT):SP:RBV PP")
+  field(DOL2, "$(P):TEMP$(OUT):SP:RBV")
+  field(LNK2, "$(P):TEMP_A:SP:RBV PP")
+  field(DOL3, "$(P):TEMP$(OUT):SP:RBV")
+  field(LNK3, "$(P):TEMP_B:SP:RBV PP")
+  field(DOL4, "$(P):TEMP$(OUT):SP:RBV")
+  field(LNK4, "$(P):TEMP_C:SP:RBV PP")
+  field(DOL5, "$(P):TEMP$(OUT):SP:RBV")
+  field(LNK5, "$(P):TEMP_D:SP:RBV PP")
+  field(SELM, "Specified")
+}
+
+##
 ## A few records to fetch the temperature read on the corresponding input channel
 ## This is so users can define a block as TEMP_1
+##
 record(calcout, "$(P):SELECT_WHICH_TEMP$(OUT)") {
   field(INPA, "$(P):CTRL_IN$(OUT).VAL CP")
   field(CALC, "A<=4 ? A : 0")

--- a/lakeshore336/lakeshore336App/Db/lakeshore336output.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336output.template
@@ -156,7 +156,8 @@ alias("$(P):RAMP_ON$(OUT)", "$(P):RAMP_ON$(OUT):SP:RBV")
 
 ## 
 ## Read the range parameter (the heater output power range).
-## This is output specific and is defined in another file.
+## IMPORTANT: This is the part of the record that is common to both output types
+## The strings are output specific and are defined in another file.
 ##
 record(mbbi, "$(P):HEATER$(OUT):RANGE") {
   field(DESC, "Output $(OUT) Heater Output Power Range")
@@ -248,7 +249,8 @@ alias("$(P):D$(OUT)", "$(P):D$(OUT):SP:RBV")
 ##
 ## Read the mode to use for outmode.
 ## This also populates the CTRL_IN and POWERUP records.
-## The mbbi strings and values are defined in the output specific templates.
+## IMPORTANT: This is the part of the record that is common to both output types
+## The strings are output specific and are defined in another file.
 ##
 record(mbbi, "$(P):OUT_MODE$(OUT)") {
   field(DESC, "Output $(OUT) Output Mode")
@@ -522,7 +524,8 @@ record(stringout, "$(P):SET_$(OUT)_INPUTD_LINK") {
 
 ## 
 ## Set the range parameter.
-## The strings are output specific and is defined in another file.
+## IMPORTANT: This is the part of the record that is common to both output types
+## The strings are output specific and are defined in another file.
 ##
 record(mbbo, "$(P):HEATER$(OUT):RANGE:SP") {
   field(DESC, "Set Output $(OUT) Heater Output Power Range")
@@ -660,7 +663,8 @@ record(ao, "$(P):D$(OUT):SP") {
 
 ##
 ## Set the mode to use for outmode
-## The strings are output specific. This is defined in another file.
+## IMPORTANT: This is the part of the record that is common to both output types
+## The strings are output specific and are defined in another file.
 ##
 record(mbbo, "$(P):OUT_MODE$(OUT):SP") {
   field(DESC, "Set Output $(OUT) Output Mode")

--- a/lakeshore336/lakeshore336App/Db/lakeshore336output.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336output.template
@@ -102,7 +102,7 @@ record(sel, "$(P):FETCH_TEMP$(OUT)") {
 }
 
 record(ai, "$(P):TEMP$(OUT)") {
-  field(DESC, "Temp read on input channel for output $(OUT)")
+  field(DESC, "Output $(OUT) Temperature Reading")
   field(INP, "$(P):FETCH_TEMP$(OUT)")
   field(PREC, "3")
   field(EGU, "K")

--- a/lakeshore336/lakeshore336App/Db/lakeshore336output.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore336output.template
@@ -269,6 +269,65 @@ record(ao, "$(P):TEMP$(OUT):SP") {
   info(archive, "VAL")
 }
 
+##
+## A few records to fetch the setpoint from that set in the input
+## This way, the user can define a block pointing at the sp in the input file,
+## and setting the block will still work
+## INPC is needed because this has to trigger whenever the input is processed,
+## not just when it changes value! Otherwise if we swap to e.g. INPUT B and then re-set INPUT_B:SP to
+## what it is already, the value doesn't get pushed
+## NOTE: can't do simply with a single sel record, because you still want to
+## trigger only when the relevant PV from the input changes
+##
+
+record(calcout, "$(P):PUSH_SP_$(OUT)_FROM_A") {
+  field(DESC, "Fetch SP$(OUT) from A if needed")
+  field(INPA, "$(P):TEMP_A:SP")
+  field(INPB, "$(P):CTRL_IN$(OUT).VAL")
+  field(INPC, "$(P):TEMP_A:SP_WAS_PROC CP")
+  field(CALC, "B == 1")
+  field(OOPT, "When Non-zero")
+  field(OCAL, "A")
+  field(DOPT, "Use OCAL")
+  field(OUT, "$(P):TEMP$(OUT):SP PP")
+}
+
+record(calcout, "$(P):PUSH_SP_$(OUT)_FROM_B") {
+  field(DESC, "Fetch SP$(OUT) from B if needed")
+  field(INPA, "$(P):TEMP_B:SP")
+  field(INPB, "$(P):CTRL_IN$(OUT).VAL")
+  field(INPC, "$(P):TEMP_B:SP_WAS_PROC CP")
+  field(CALC, "B == 2")
+  field(OOPT, "When Non-zero")
+  field(OCAL, "A")
+  field(DOPT, "Use OCAL")
+  field(OUT, "$(P):TEMP$(OUT):SP PP")
+}
+
+record(calcout, "$(P):PUSH_SP_$(OUT)_FROM_C") {
+  field(DESC, "Fetch SP$(OUT) from C if needed")
+  field(INPA, "$(P):TEMP_C:SP")
+  field(INPB, "$(P):CTRL_IN$(OUT).VAL")
+  field(INPC, "$(P):TEMP_C:SP_WAS_PROC CP")
+  field(CALC, "B == 3")
+  field(OOPT, "When Non-zero")
+  field(OCAL, "A")
+  field(DOPT, "Use OCAL")
+  field(OUT, "$(P):TEMP$(OUT):SP PP")
+}
+
+record(calcout, "$(P):PUSH_SP_$(OUT)_FROM_D") {
+  field(DESC, "Fetch SP$(OUT) from D if needed")
+  field(INPA, "$(P):TEMP_D:SP")
+  field(INPB, "$(P):CTRL_IN$(OUT).VAL")
+  field(INPC, "$(P):TEMP_D:SP_WAS_PROC CP")
+  field(CALC, "B == 4")
+  field(OOPT, "When Non-zero")
+  field(OCAL, "A")
+  field(DOPT, "Use OCAL")
+  field(OUT, "$(P):TEMP$(OUT):SP PP")
+}
+
 ###############################################################################
 
 ##

--- a/lakeshore336/lakeshore336App/Db/lakeshore_input.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore_input.template
@@ -106,6 +106,19 @@ record(ao, "$(P):TEMP_$(INPUT):SP") {
 }
 
 ##
+## Hold the temperature setpoint readback on this channel in Kelvin.
+## The actual RBV is in the output and gets pushed here
+## This is for completeness, as we have TEMP_X and TEMP_X:SP, so we have also TEMP_X:SP:RBV
+##
+record(ai, "$(P):TEMP_$(INPUT):SP:RBV") {
+  field(DESC, "Input $(INPUT) Temperature Setpoint Readback")
+  field(PREC, "3")
+  field(EGU, "K")
+  info(INTEREST, "HIGH")
+  info(archive, "VAL")
+}
+
+##
 ## Flag when the SP above has processed, even if value is unchanged,
 ## because output needs to know even if the value hasn't changed
 ##

--- a/lakeshore336/lakeshore336App/Db/lakeshore_input.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore_input.template
@@ -92,6 +92,29 @@ record(ai, "$(P):TEMP_$(INPUT)") {
 }
 
 ## 
+## Hold the temperature setpoint on this channel in Kelvin.
+## The actual set happens in the output
+## This way, when a block points at the temperature for this input, it can be set too
+##
+record(ao, "$(P):TEMP_$(INPUT):SP") {
+  field(DESC, "Input $(INPUT) Temperature Setpoint")
+  field(PREC, "3")
+  field(EGU, "K")
+  field(FLNK, "$(P):TEMP_$(INPUT):SP_WAS_PROC")
+  info(INTEREST, "HIGH")
+  info(archive, "VAL")
+}
+
+##
+## Flag when the SP above has processed, even if value is unchanged,
+## because output needs to know even if the value hasn't changed
+##
+record(calc, "$(P):TEMP_$(INPUT):SP_WAS_PROC") {
+  field(INPA, "$(P):TEMP_$(INPUT):SP_WAS_PROC")
+  field(CALC, "!A")
+}
+
+## 
 ## Read the raw voltage on this channel.
 ##
 record(ai, "$(P):RAW_VOLT_$(INPUT)") {

--- a/lakeshore336/lakeshore336App/Db/lakeshore_input.template
+++ b/lakeshore336/lakeshore336App/Db/lakeshore_input.template
@@ -97,7 +97,7 @@ record(ai, "$(P):TEMP_$(INPUT)") {
 ## This way, when a block points at the temperature for this input, it can be set too
 ##
 record(ao, "$(P):TEMP_$(INPUT):SP") {
-  field(DESC, "Input $(INPUT) Temperature Setpoint")
+  field(DESC, "Set Input $(INPUT) Temperature Setpoint")
   field(PREC, "3")
   field(EGU, "K")
   field(FLNK, "$(P):TEMP_$(INPUT):SP_WAS_PROC")


### PR DESCRIPTION
This is for ticket ISISComputingGroup/IBEX#1692

[NOTE: I've also added a DISABLE macro, for consistency with other IOCs. The macro is set in the actual IOC, see pull request ISISComputingGroup/EPICS-ioc#99 so can you please merge that too ]

Originally we had these PVs:
For output 1:
    TEMP1:SP, TEMP1:SP:RBV   (same for output 2)
For input A:
    TEMP_A   (same for inputs B, C, D)
This meant a block pointing at TEMP_A was missing the corresponding setpoint

With this fix we now have all the possible options:
For output 1:
    TEMP1, TEMP1:SP, TEMP1:SP:RBV (same for output 2)
For input A:
    TEMP_A, TEMP_A:SP, TEMP_A:SP:RBV (same for inputs B, C, D)

So now a user can make blocks pointing at either the input or the output.

For testing, this IOC can run in either RECSIM mode or DEVSIM mode (there is an emulator for it).
Things to test:
* when the temperature reading on the input changes (e.g. TEMP_A), so does the one in the output using that input (e.g. TEMP_1). Changing the control input (in the output settings) to other values, including None, should behave as you would expect it to: if output 1 points at input A/B/C/D, it should read from them; on None it should read 0
* when the setpoint is set via the input (e.g. TEMP_A:SP), any output pointing at that input should have its setpoint changed too. Again, check switching control input, also to None and back. If I switch say output 1 from input A to input B, I don't expect TEMP1:SP to change from TEMP_A:SP to TEMP_B:SP until TEMP_B:SP is set again. Note that the OPI points at TEMP1:SP, so you should be able to alternate setting the setpoint from the output or input side (e.g. with a block) without anything weird happening
* whatever the value of TEMP1:SP:RBV, it should come up as TEMP_A:SP:RBV (or B/C/D depending on the setting). Again switching control input should work as expected